### PR TITLE
Add tests for test result output file in libtest

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -415,6 +415,8 @@ dependencies = [
  "core",
  "getopts",
  "libc",
+ "rand",
+ "rand_xorshift",
  "std",
 ]
 

--- a/library/test/Cargo.toml
+++ b/library/test/Cargo.toml
@@ -10,5 +10,10 @@ getopts = { version = "0.2.21", features = ['rustc-dep-of-std'] }
 std = { path = "../std", public = true }
 core = { path = "../core", public = true }
 
+[dev-dependencies]
+rand = { version = "0.9.0", default-features = false, features = ["alloc"] }
+rand_xorshift = "0.4.0"
+
+
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
 libc = { version = "0.2.150", default-features = false }

--- a/library/test/src/console.rs
+++ b/library/test/src/console.rs
@@ -172,7 +172,7 @@ impl ConsoleTestState {
 
 // List the tests to console, and optionally to logfile. Filters are honored.
 pub(crate) fn list_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Result<()> {
-    let output = build_output(&opts.test_results_file)?;
+    let output = build_test_output(&opts.test_results_file)?;
     let mut out: Box<dyn OutputFormatter> = match opts.format {
         OutputFormat::Pretty | OutputFormat::Junit => {
             Box::new(PrettyFormatter::new(output, false, 0, false, None))
@@ -208,7 +208,7 @@ pub(crate) fn list_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> 
     out.write_discovery_finish(&st)
 }
 
-pub(crate) fn build_output(
+pub(crate) fn build_test_output(
     test_results_file: &Option<PathBuf>,
 ) -> io::Result<OutputLocation<Box<dyn Write>>> {
     let output: OutputLocation<Box<dyn Write>> = match test_results_file {
@@ -299,7 +299,7 @@ fn on_test_event(
 /// A simple console test runner.
 /// Runs provided tests reporting process and results to the stdout.
 pub fn run_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Result<bool> {
-    let output = build_output(&opts.test_results_file)?;
+    let output = build_test_output(&opts.test_results_file)?;
 
     let max_name_len = tests
         .iter()

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -80,6 +80,10 @@ mod types;
 #[cfg(test)]
 mod tests;
 
+#[allow(dead_code)] // Not used in all configurations.
+#[cfg(test)]
+mod test_helpers;
+
 use core::any::Any;
 
 use event::{CompletedTest, TestEvent};

--- a/library/test/src/test_helpers.rs
+++ b/library/test/src/test_helpers.rs
@@ -1,0 +1,61 @@
+use std::hash::{BuildHasher, Hash, Hasher, RandomState};
+use std::path::PathBuf;
+use std::{env, fs, thread};
+
+use rand::{RngCore, SeedableRng};
+
+use crate::panic::Location;
+
+/// Test-only replacement for `rand::thread_rng()`, which is unusable for
+/// us, as we want to allow running stdlib tests on tier-3 targets which may
+/// not have `getrandom` support.
+///
+/// Does a bit of a song and dance to ensure that the seed is different on
+/// each call (as some tests sadly rely on this), but doesn't try that hard.
+///
+/// This is duplicated in the `core`, `alloc` test suites (as well as
+/// `std`'s integration tests), but figuring out a mechanism to share these
+/// seems far more painful than copy-pasting a 7 line function a couple
+/// times, given that even under a perma-unstable feature, I don't think we
+/// want to expose types from `rand` from `std`.
+#[track_caller]
+pub(crate) fn test_rng() -> rand_xorshift::XorShiftRng {
+    let mut hasher = RandomState::new().build_hasher();
+    Location::caller().hash(&mut hasher);
+    let hc64 = hasher.finish();
+    let seed_vec = hc64.to_le_bytes().into_iter().chain(0u8..8).collect::<Vec<u8>>();
+    let seed: [u8; 16] = seed_vec.as_slice().try_into().unwrap();
+    SeedableRng::from_seed(seed)
+}
+
+pub(crate) struct TempDir(PathBuf);
+
+impl TempDir {
+    pub(crate) fn join(&self, path: &str) -> PathBuf {
+        let TempDir(ref p) = *self;
+        p.join(path)
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        // Gee, seeing how we're testing the fs module I sure hope that we
+        // at least implement this correctly!
+        let TempDir(ref p) = *self;
+        let result = fs::remove_dir_all(p);
+        // Avoid panicking while panicking as this causes the process to
+        // immediately abort, without displaying test results.
+        if !thread::panicking() {
+            result.unwrap();
+        }
+    }
+}
+
+#[track_caller] // for `test_rng`
+pub(crate) fn tmpdir() -> TempDir {
+    let p = env::temp_dir();
+    let mut r = test_rng();
+    let ret = p.join(&format!("rust-{}", r.next_u32()));
+    fs::create_dir(&ret).unwrap();
+    TempDir(ret)
+}

--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -1,18 +1,14 @@
+use std::fs::{self, File};
 use std::path::PathBuf;
 
+use rand::RngCore;
+
 use super::*;
-use crate::{
-    console::OutputLocation,
-    formatters::PrettyFormatter,
-    test::{
-        MetricMap,
-        // FIXME (introduced by #65251)
-        // ShouldPanic, StaticTestName, TestDesc, TestDescAndFn, TestOpts, TestTimeOptions,
-        // TestType, TrFailedMsg, TrIgnored, TrOk,
-        parse_opts,
-    },
-    time::{TestTimeOptions, TimeThreshold},
-};
+use crate::console::{OutputLocation, build_test_output};
+use crate::formatters::PrettyFormatter;
+use crate::test::{MetricMap, parse_opts};
+use crate::test_helpers::{test_rng, tmpdir};
+use crate::time::{TestTimeOptions, TimeThreshold};
 
 impl TestOpts {
     fn new() -> TestOpts {
@@ -937,4 +933,35 @@ fn test_dyn_bench_returning_err_fails_when_run_as_test() {
     run_tests(&TestOpts { run_tests: true, ..TestOpts::new() }, vec![desc], notify).unwrap();
     let result = rx.recv().unwrap().result;
     assert_eq!(result, TrFailed);
+}
+
+#[test]
+fn test_result_output_propagated_to_file() {
+    let tmpdir = tmpdir();
+    let test_results_file = tmpdir.join("test_results");
+    let mut output = build_test_output(&Some(test_results_file.clone())).unwrap();
+    let random_str = format!("test_result_file_contents_{}", test_rng().next_u32());
+
+    match output {
+        OutputLocation::Raw(ref mut m) => {
+            m.write_all(random_str.as_bytes()).unwrap();
+            m.flush().unwrap()
+        }
+        OutputLocation::Pretty(_) => unreachable!(),
+    };
+
+    let file_contents = fs::read_to_string(test_results_file).unwrap();
+    assert_eq!(random_str, file_contents);
+}
+
+#[test]
+fn test_result_output_bails_when_file_exists() {
+    let tmpdir = tmpdir();
+    let test_results_file = tmpdir.join("test_results");
+    let new_file = File::create(&test_results_file).unwrap();
+    drop(new_file);
+
+    let maybe_output = build_test_output(&Some(test_results_file));
+
+    assert_eq!(maybe_output.err().map(|e| e.kind()), Some(io::ErrorKind::AlreadyExists));
 }


### PR DESCRIPTION
Stacked PRs:
 * __->__#3
 * #2


--- --- ---

### Add tests for test result output file in libtest


I had to introduce `test_helepr.rs` basically re-copying it yet another time from `std` as it was done in other places. It is better than keeping new functionality untested.